### PR TITLE
[Patch]解决性能问题（？

### DIFF
--- a/src/plugins/group/join_manager.py
+++ b/src/plugins/group/join_manager.py
@@ -20,7 +20,6 @@ from src.plugins.menu.manager import MatcherData
 @on_command(
     "入群验证",
     aliases={"robot_fight", "anti_robot"},
-    permission=is_group_admin,
     state=MatcherData(
         rm_name="入群验证",
         rm_desc="入群验证",
@@ -30,6 +29,8 @@ from src.plugins.menu.manager import MatcherData
 async def cmd(
     bot: Bot, event: GroupMessageEvent, matcher: Matcher, args: Message = CommandArg()
 ) -> None:
+    if not await is_group_admin(event, bot):
+        return
     config, _ = await GroupConfig.get_or_create(group_id=event.group_id)
     if arg := args.extract_plain_text().strip().lower():
         if arg in ("启用", "on", "enable", "开启", "yes", "y", "true"):

--- a/src/plugins/group/join_manager.py
+++ b/src/plugins/group/join_manager.py
@@ -20,7 +20,7 @@ from src.plugins.menu.manager import MatcherData
 @on_command(
     "入群验证",
     aliases={"robot_fight", "anti_robot"},
-    rule=is_group_admin,
+    permission=is_group_admin,
     state=MatcherData(
         rm_name="入群验证",
         rm_desc="入群验证",

--- a/src/plugins/group/recall.py
+++ b/src/plugins/group/recall.py
@@ -1,4 +1,4 @@
-from nonebot import on_message
+from nonebot import on_command
 from nonebot.adapters.onebot.v11 import (
     Bot,
     GroupMessageEvent,
@@ -8,8 +8,9 @@ from nonebot.matcher import Matcher
 from litebot_utils.rule import is_group_admin
 from src.plugins.menu.manager import MatcherData
 
-recall = on_message(
-    rule=is_group_admin,
+recall = on_command(
+    "recall",
+    permission=is_group_admin,
     state=MatcherData(
         rm_name="撤回消息",
         rm_desc="用机器人撤回一条消息",
@@ -19,8 +20,6 @@ recall = on_message(
 
 @recall.handle()
 async def _(event: GroupMessageEvent, bot: Bot, matcher: Matcher):
-    if "/recall" not in event.raw_message:
-        return
     if not event.reply:
         await matcher.finish("请回复消息选择撤回")
 

--- a/src/plugins/group/recall.py
+++ b/src/plugins/group/recall.py
@@ -10,7 +10,6 @@ from src.plugins.menu.manager import MatcherData
 
 recall = on_command(
     "recall",
-    permission=is_group_admin,
     state=MatcherData(
         rm_name="撤回消息",
         rm_desc="用机器人撤回一条消息",
@@ -20,6 +19,8 @@ recall = on_command(
 
 @recall.handle()
 async def _(event: GroupMessageEvent, bot: Bot, matcher: Matcher):
+    if not await is_group_admin(event, bot):
+        return
     if not event.reply:
         await matcher.finish("请回复消息选择撤回")
 

--- a/src/plugins/group/switch.py
+++ b/src/plugins/group/switch.py
@@ -1,6 +1,7 @@
 
 from nonebot import get_driver, on_command
 from nonebot.adapters.onebot.v11 import (
+    Bot,
     GroupMessageEvent,
     Message,
 )
@@ -14,7 +15,6 @@ from src.plugins.menu.manager import MatcherData
 command_start = get_driver().config.command_start
 switch = on_command(
     "switch",
-    permission=is_group_admin,
     state=MatcherData(
         rm_name="切换LiteBot启用状态",
         rm_desc="切换LiteBot启用状态",
@@ -23,7 +23,11 @@ switch = on_command(
 )
 
 @switch.handle()
-async def _(event: GroupMessageEvent, matcher: Matcher, arg: Message = CommandArg()):
+async def _(
+    event: GroupMessageEvent, matcher: Matcher, bot: Bot, arg: Message = CommandArg()
+):
+    if not await is_group_admin(event, bot):
+        await switch.finish("你没有权限使用此命令！")
     """开关"""
     # 获取当前群组的开关状态
     group_id = event.group_id

--- a/src/plugins/group/switch.py
+++ b/src/plugins/group/switch.py
@@ -14,7 +14,7 @@ from src.plugins.menu.manager import MatcherData
 command_start = get_driver().config.command_start
 switch = on_command(
     "switch",
-    rule=is_group_admin,
+    permission=is_group_admin,
     state=MatcherData(
         rm_name="切换LiteBot启用状态",
         rm_desc="切换LiteBot启用状态",

--- a/src/plugins/group/welcome_switch.py
+++ b/src/plugins/group/welcome_switch.py
@@ -1,5 +1,6 @@
 from nonebot import get_driver, on_command
 from nonebot.adapters.onebot.v11 import (
+    Bot,
     GroupMessageEvent,
     Message,
 )
@@ -14,7 +15,6 @@ command_start = get_driver().config.command_start
 
 welcome_switch = on_command(
     "welcome",
-    permission=is_group_admin,
     state=MatcherData(
         rm_name="切换LiteBot成员变动监听状态",
         rm_desc="切换LiteBot成员变动监听状态",
@@ -23,7 +23,11 @@ welcome_switch = on_command(
 )
 
 @welcome_switch.handle()
-async def _(event: GroupMessageEvent, matcher: Matcher, arg: Message = CommandArg()):
+async def _(
+    event: GroupMessageEvent, matcher: Matcher, bot: Bot, arg: Message = CommandArg()
+):
+    if not await is_group_admin(event, bot):
+        return
     """开关"""
     # 获取当前群组的开关状态
     gid = event.group_id

--- a/src/plugins/group/welcome_switch.py
+++ b/src/plugins/group/welcome_switch.py
@@ -14,7 +14,7 @@ command_start = get_driver().config.command_start
 
 welcome_switch = on_command(
     "welcome",
-    rule=is_group_admin,
+    permission=is_group_admin,
     state=MatcherData(
         rm_name="切换LiteBot成员变动监听状态",
         rm_desc="切换LiteBot成员变动监听状态",

--- a/src/plugins/manager/auto_clean.py
+++ b/src/plugins/manager/auto_clean.py
@@ -7,7 +7,7 @@ from src.plugins.menu.manager import MatcherData
 
 clean_groups = on_command(
     "clean_groups",
-    rule=is_admin,
+    permission=is_admin,
     state=MatcherData(
         rm_name="无用群组清理",
         rm_desc="清理人数小于20的无效聊群",

--- a/src/plugins/manager/ban.py
+++ b/src/plugins/manager/ban.py
@@ -6,7 +6,7 @@ from litebot_utils.blacklist.black import bl_manager
 from litebot_utils.rule import is_admin
 from src.plugins.menu.manager import MatcherData
 
-ban = CommandGroup("ban", rule=is_admin)
+ban = CommandGroup("ban", permission=is_admin)
 
 ban_group = ban.command(
     "group",

--- a/src/plugins/manager/leave.py
+++ b/src/plugins/manager/leave.py
@@ -10,7 +10,7 @@ from src.plugins.menu.manager import MatcherData
 
 @on_command(
     "set_leave",
-    rule=is_admin,
+    permission=is_admin,
     state=MatcherData(
         rm_name="退出指定聊群",
         rm_desc="用于退出聊群",

--- a/src/plugins/manager/pardon.py
+++ b/src/plugins/manager/pardon.py
@@ -6,7 +6,7 @@ from litebot_utils.blacklist.black import bl_manager
 from litebot_utils.rule import is_admin
 from src.plugins.menu.manager import MatcherData
 
-pardon = CommandGroup("pardon", rule=is_admin)
+pardon = CommandGroup("pardon", permission=is_admin)
 
 pardon_group = pardon.command(
     "group",


### PR DESCRIPTION
resolve #56

## Summary by Sourcery

Standardize permission enforcement across group and manager plugins and refine the recall command to use command-based invocation with proper admin checks.

Bug Fixes:
- Fix recall command to restrict unauthorized use and enforce message reply for recalls

Enhancements:
- Convert recall plugin from on_message to on_command with admin permission
- Replace rule-based admin checks with permission parameters for group and manager commands
- Add explicit is_group_admin checks inside switch, welcome_switch, and join_manager handlers