### PR TITLE
添加新指令，修复部分错误

### DIFF
--- a/src/plugins/datafunc/qr.py
+++ b/src/plugins/datafunc/qr.py
@@ -1,10 +1,11 @@
-import io
 import base64
+import io
 
 import qrcode
 from nonebot import logger, on_command
-from nonebot.adapters.onebot.v11 import MessageEvent, MessageSegment
+from nonebot.adapters.onebot.v11 import Message, MessageSegment
 from nonebot.matcher import Matcher
+from nonebot.params import CommandArg
 
 from src.plugins.menu.manager import MatcherData
 
@@ -16,8 +17,8 @@ from src.plugins.menu.manager import MatcherData
         rm_name="qr", rm_usage="qr <text>", rm_desc="文本->二维码"
     ).model_dump(),
 ).handle()
-async def qr_runner(matcher: Matcher, event: MessageEvent):
-    if location := event.message.extract_plain_text().strip():
+async def qr_runner(matcher: Matcher, args: Message = CommandArg()):
+    if location := args.extract_plain_text().strip():
         try:
             img = qrcode.make(location)
             bytesio = io.BytesIO()

--- a/src/plugins/group/join_manager.py
+++ b/src/plugins/group/join_manager.py
@@ -71,6 +71,7 @@ async def checker(bot: Bot, event: GroupMessageEvent, matcher: Matcher):
                     and v.get("group_id") == event.group_id
                 ):
                     del pending_cancelable_msg[k]
+                    break
             matcher.stop_propagation()
         elif any(
             isinstance(msg, dict) and msg.get("type") in ["json", "xml", "share"]

--- a/src/plugins/group/join_manager.py
+++ b/src/plugins/group/join_manager.py
@@ -130,7 +130,7 @@ async def handle_join(bot: Bot, event: GroupIncreaseNoticeEvent, matcher: Matche
         return
     captcha = random.randint(10000, 99999)
     captcha_manager.add(event.group_id, event.user_id, captcha)
-    sended_msg_id: int = (
+    sent_msg_id: int = (
         await matcher.send(
             MessageSegment.at(event.user_id)
             + MessageSegment.text(
@@ -140,7 +140,7 @@ async def handle_join(bot: Bot, event: GroupIncreaseNoticeEvent, matcher: Matche
     )["message_id"]
     captcha_manager.pending(event.group_id, event.user_id, bot)
 
-    pending_cancelable_msg[str(sended_msg_id)] = {
+    pending_cancelable_msg[str(sent_msg_id)] = {
         "group_id": str(event.group_id),
         "user_id": str(event.user_id),
     }

--- a/src/plugins/group/join_manager.py
+++ b/src/plugins/group/join_manager.py
@@ -130,7 +130,7 @@ async def handle_join(bot: Bot, event: GroupIncreaseNoticeEvent, matcher: Matche
         return
     captcha = random.randint(10000, 99999)
     captcha_manager.add(event.group_id, event.user_id, captcha)
-    sended_msg_id: str = (
+    sended_msg_id: int = (
         await matcher.send(
             MessageSegment.at(event.user_id)
             + MessageSegment.text(

--- a/src/plugins/group/join_manager.py
+++ b/src/plugins/group/join_manager.py
@@ -67,8 +67,8 @@ async def checker(bot: Bot, event: GroupMessageEvent, matcher: Matcher):
             captcha_manager.remove(event.group_id, event.user_id)
             for k, v in pending_cancelable_msg.items():
                 if (
-                    v.get("user_id") == event.user_id
-                    and v.get("group_id") == event.group_id
+                    v.get("user_id") == str(event.user_id)
+                    and v.get("group_id") == str(event.group_id)
                 ):
                     del pending_cancelable_msg[k]
                     break

--- a/src/plugins/group/join_manager.py
+++ b/src/plugins/group/join_manager.py
@@ -65,7 +65,8 @@ async def checker(bot: Bot, event: GroupMessageEvent, matcher: Matcher):
                 + MessageSegment.text(f"验证成功！欢迎加入{group_name}！"),
             )
             captcha_manager.remove(event.group_id, event.user_id)
-            for k, v in pending_cancelable_msg.items():
+            for k in list(pending_cancelable_msg):
+                v = pending_cancelable_msg[k]
                 if (
                     v.get("user_id") == str(event.user_id)
                     and v.get("group_id") == str(event.group_id)

--- a/src/plugins/group/notice.py
+++ b/src/plugins/group/notice.py
@@ -119,7 +119,10 @@ async def handle_member_leave(
             + MessageSegment.text("退出了群聊")
         )
     else:
-        message = f"{uid}{' 被 ' + (str(event.operator_id) if event.operator_id != 0 else '')} 赠送了飞机票。"
+        if event.operator_id == 0:
+            message = f"{uid} 被赠送了飞机票。"
+        else:
+            message = f"{uid} 被 {event.operator_id} 赠送了飞机票。"
     await bot.send_group_msg(group_id=gid, message=message)
 
 

--- a/src/plugins/group/notice.py
+++ b/src/plugins/group/notice.py
@@ -40,7 +40,6 @@ async def handle_poke(event: PokeNotifyEvent, bot: Bot, matcher: Matcher):
 
 @notice.handle()
 async def handle_group_notice(event: GroupEvent, bot: Bot, matcher: Matcher):
-
     gid, uid, self_id = event.group_id, event.user_id, event.self_id
     group_config = await GroupConfig.get_or_none(group_id=gid)
     if not group_config or not group_config.switch or not group_config.welcome:
@@ -120,7 +119,7 @@ async def handle_member_leave(
             + MessageSegment.text("退出了群聊")
         )
     else:
-        message = f"{uid} 被 {event.operator_id} 赠送了飞机票。"
+        message = f"{uid}{' 被 ' + (str(event.operator_id) if event.operator_id != 0 else '')} 赠送了飞机票。"
     await bot.send_group_msg(group_id=gid, message=message)
 
 

--- a/src/plugins/group/recall.py
+++ b/src/plugins/group/recall.py
@@ -1,4 +1,4 @@
-from nonebot import on_command
+from nonebot import on_message
 from nonebot.adapters.onebot.v11 import (
     Bot,
     GroupMessageEvent,

--- a/src/plugins/group/recall.py
+++ b/src/plugins/group/recall.py
@@ -18,8 +18,6 @@ recall = on_message(
 
 @recall.handle()
 async def _(event: GroupMessageEvent, bot: Bot, matcher: Matcher):
-    if not await is_group_admin(event, bot):
-        return
     if not event.reply:
         await matcher.finish("请回复消息选择撤回")
     if not await is_group_admin(event, bot):

--- a/src/plugins/group/recall.py
+++ b/src/plugins/group/recall.py
@@ -9,7 +9,6 @@ from litebot_utils.rule import is_group_admin
 from src.plugins.menu.manager import MatcherData
 
 recall = on_message(
-    rule=is_group_admin,
     state=MatcherData(
         rm_name="撤回消息",
         rm_desc="用机器人撤回一条消息",
@@ -23,6 +22,7 @@ async def _(event: GroupMessageEvent, bot: Bot, matcher: Matcher):
         return
     if not event.reply:
         await matcher.finish("请回复消息选择撤回")
-
+    if not await is_group_admin(event, bot):
+        return
     await bot.delete_msg(message_id=event.reply.message_id)
     await matcher.finish("已尝试撤回消息！")

--- a/src/plugins/manager/__init__.py
+++ b/src/plugins/manager/__init__.py
@@ -4,7 +4,7 @@ from . import add, auto_clean, ban, black, leave, pardon, rate
 
 __plugin_meta__ = PluginMetadata(
     name="管理插件",
-    description="管理器（TO管理员：您的每一个操作都会让用户发出尖锐的爆鸣声）",
+    description="管理器（仅机器人超管可用）（TO管理员：您的每一个操作都会让用户发出尖锐的爆鸣声）",
     usage="管理器插件",
     type="application",
 )


### PR DESCRIPTION
## Summary by Sourcery

Add reply-based `/skip` command to cancel group join verifications and clean up stale entries; refactor several command handlers for inline argument and permission handling; fix notice formatting and update plugin metadata description.

New Features:
- Allow replying to a bot verification message with `/skip` to cancel a pending group join validation.

Bug Fixes:
- Clean up stale pending verification entries upon successful captcha validation.
- Correct group member leave notice to avoid redundant “被” text when no operator ID is present.

Enhancements:
- Refactor recall plugin to trigger on any message with inline admin permission check.
- Switch QR code command to use `CommandArg` for cleaner argument extraction.
- Capture and map join verification message IDs when sending captchas.
- Clarify plugin metadata description to indicate super-admin usage.