### PR TITLE
更新join_manager

### DIFF
--- a/src/plugins/group/join_manager.py
+++ b/src/plugins/group/join_manager.py
@@ -28,7 +28,7 @@ pending_cancelable_msg: dict[str, dict[str, str]] = {}
 async def captcha(
     bot: Bot, matcher: Matcher, event: GroupEvent, uid: int | None = None
 ):
-    user_id = uid or event.user_id
+    user_id = event.user_id if uid is None else uid
     async with get_session() as session:
         config, _ = await get_or_create_group_config(event.group_id)
         session.add(config)

--- a/src/plugins/group/join_manager.py
+++ b/src/plugins/group/join_manager.py
@@ -28,6 +28,7 @@ pending_cancelable_msg: dict[str, dict[str, str]] = {}
 async def captcha(
     bot: Bot, matcher: Matcher, event: GroupEvent, uid: int | None = None
 ):
+    user_id = uid or event.user_id
     async with get_session() as session:
         config, _ = await get_or_create_group_config(event.group_id)
         session.add(config)
@@ -39,7 +40,6 @@ async def captcha(
         captcha_format = config.captcha_format
         captcha_timeout = config.captcha_timeout
     captcha_code = generate_captcha(captcha_length, captcha_format)
-    user_id = event.user_id if uid is None else uid
     sent_msg_id: int = (
         await matcher.send(
             MessageSegment.at(user_id)
@@ -79,11 +79,11 @@ async def _(
         if not await is_bot_group_admin(event, bot):
             config.auto_manage_join = False
             await session.commit()
-            await matcher.send("⛔ LiteBot为普通群成员！")
+            await matcher.finish("⛔ LiteBot为普通群成员！")
     for segment in args:
         if segment.type == "at":
-            uid = segment.data["qq"]
-            await captcha(bot, matcher, event, int(uid))
+            uid = int(segment.data["qq"])
+            await captcha(bot, matcher, event, uid)
             break
     else:
         await matcher.finish("⚠️ 请at需要验证的人。")
@@ -221,7 +221,7 @@ async def checker(bot: Bot, event: GroupMessageEvent, matcher: Matcher):
             await captcha_manager.remove(event.group_id, event.user_id)
             for k in list(pending_cancelable_msg):
                 v = pending_cancelable_msg[k]
-                if v.get("user_id") == str(event.user_id) and v.get("group_id") == str(
+                if v.get("user_id") == event.get_user_id() and v.get("group_id") == str(
                     event.group_id
                 ):
                     await bot.delete_msg(message_id=int(k))

--- a/src/plugins/menu/utils.py
+++ b/src/plugins/menu/utils.py
@@ -14,6 +14,7 @@ PAGE_DIR = get_config_dir("LiteBot") / "pages"
 PAGE_DIR.mkdir(parents=True, exist_ok=True)
 _md_cache: dict[str, str] = {}
 
+
 def get_css_path(style: Literal["light", "dark", ""] = "") -> str:
     if datetime.now().hour < 7 or datetime.now().hour > 20 or style == "dark":
         return str(dir_path / "dark.css")


### PR DESCRIPTION
## Sourcery 总结

优化限速器，使其能一致地应用冷却时间，并选择性地为基于文本的规则（现在包括 ToMeRule）发送反馈；简化加入管理器（join manager）的验证码流程，通过统一的用户ID（user_id）处理并在权限错误时正确结束；并修复待处理消息清理中的用户ID（user_id）比较问题。在 menu utils 中添加小的格式调整。

错误修复：
- 修复清理待取消消息时用户ID（user_id）比较中的类型不匹配问题。

功能增强：
- 总是消耗限速令牌，并且只在存在基于文本的匹配器（包括新的 ToMeRule）时发送“太快了”回复。
- 统一加入管理器（join manager）的验证码处理程序中的用户ID（user_id）确定，并在管理员权限错误时将 send 替换为 finish。

杂项：
- 在 `menu/utils.py` 中插入空行以提高可读性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine rate limiter to consistently apply cooldowns and selectively send feedback for text-based rules (now including ToMeRule), simplify join manager’s captcha flow with unified user_id handling and proper finish on permission errors, and fix user_id comparison in pending message cleanup. Add minor formatting tweak in menu utils.

Bug Fixes:
- Fix type mismatch in user_id comparison when cleaning up pending cancelable messages.

Enhancements:
- Always consume rate limit tokens and only send ‘too fast’ replies when text-based matchers (including new ToMeRule) are present.
- Unify user_id determination in join_manager’s captcha handler and replace send with finish for admin permission errors.

Chores:
- Insert blank line for readability in menu/utils.py.

</details>