### PR TITLE
fix:修复传参

### DIFF
--- a/src/plugins/group/bad_words.py
+++ b/src/plugins/group/bad_words.py
@@ -61,7 +61,7 @@ async def _(event: GroupMessageEvent, bot: Bot, matcher: Matcher):
     group_id = event.group_id
     if event.sender.role != "member":
         return
-    if not await is_check_enabled():
+    if not await is_check_enabled(event.group_id):
         return
     async with get_session() as session:
         config, _ = await get_or_create_group_config(group_id)


### PR DESCRIPTION
## Sourcery 摘要

Bug 修复：
- 将缺少的 `group_id` 参数传递给 `bad_words` 过滤器中的 `is_check_enabled`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Pass the missing group_id parameter to is_check_enabled in bad_words filter

</details>